### PR TITLE
Fix/deprecated erb usage

### DIFF
--- a/lib/orogen/gen/templates.rb
+++ b/lib/orogen/gen/templates.rb
@@ -51,8 +51,8 @@ module OroGen
 
                     templates[path] =
                         begin
-                            ERB.new(File.read(template_file), nil, "<>",
-                                    path.join("_").downcase.gsub(%r{[\/\.-]}, "_"))
+                            ERB.new(File.read(template_file), trim_mode: "<>",
+                                    eoutvar: path.join("_").downcase.gsub(%r{[\/\.-]}, "_"))
                         rescue Errno::ENOENT
                             raise ArgumentError, "template #{File.join(*path)} "\
                                                  "does not exist"


### PR DESCRIPTION
Without this fix, recently building with Ubuntu 24 broke with errors like

    std.orogen: wrong number of arguments (given 4, expected 1) (ArgumentError)

(No stacktrace, but fortunately Ubuntu 20.04 gave deprecation warnings with call location)